### PR TITLE
feat: Add argument support for CLI jobs

### DIFF
--- a/src/entrypoints/cli/app.py
+++ b/src/entrypoints/cli/app.py
@@ -47,10 +47,12 @@ def cli():
     pass
 
 
-@cli.group(name="job")
-def job_group():
+@cli.group(name="job", invoke_without_command=True)
+@click.pass_context
+def job_group(ctx):
     """Execute background jobs and cronjobs"""
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @job_group.command(name="list")

--- a/src/entrypoints/cli/app.py
+++ b/src/entrypoints/cli/app.py
@@ -3,7 +3,6 @@ CLI Application Entry Point
 
 Background Jobs and Cronjobs using Click
 """
-import asyncio
 import click
 from loguru import logger
 
@@ -12,7 +11,28 @@ from __about__ import __version__
 from .dependencies import CLIDependencies
 from .jobs import register_all_jobs
 from .job_registry import JobRegistry
-from .job_handler import JobHandler
+
+
+# Global state for lazy initialization
+_deps_initialized = False
+
+
+def _init_deps() -> None:
+    """Lazy dependency initialization"""
+    global _deps_initialized
+    if not _deps_initialized:
+        app_config = Config()
+        CLIDependencies.initialize(app_config)
+        logger.info("CLI dependencies initialized")
+        _deps_initialized = True
+
+
+def _cleanup_deps() -> None:
+    """Cleanup dependencies"""
+    global _deps_initialized
+    if _deps_initialized:
+        CLIDependencies.clear()
+        _deps_initialized = False
 
 
 @click.group(name="void")
@@ -33,53 +53,6 @@ def job_group():
     pass
 
 
-@job_group.command(name="run")
-@click.argument("job_name")
-def run_job(job_name: str):
-    """
-    Run a specific job by name
-
-    JOB_NAME is the name of the registered job (function name).
-
-    Example:
-        void job run cleanup_items
-    """
-    asyncio.run(_execute_job(job_name))
-
-
-async def _execute_job(job_name: str):
-    """
-    Execute job with async support
-
-    Args:
-        job_name: Job identifier
-    """
-    logger.info(f"Initializing VOID CLI: job={job_name}")
-
-    # Load configuration from .env
-    app_config = Config()
-
-    # Initialize dependencies
-    CLIDependencies.initialize(app_config)
-    logger.info("CLI dependencies initialized")
-
-    # Register all jobs
-    register_all_jobs()
-    logger.info(f"Registered jobs: {JobRegistry.list_jobs()}")
-
-    # Execute job
-    handler = JobHandler()
-    try:
-        await handler.execute(job_name)
-        logger.info(f"Job completed: {job_name}")
-    except Exception as e:
-        logger.error(f"Job failed: {job_name}, error: {e}", exc_info=True)
-        raise click.ClickException(str(e))
-    finally:
-        # Cleanup
-        CLIDependencies.clear()
-
-
 @job_group.command(name="list")
 def list_jobs():
     """
@@ -87,17 +60,6 @@ def list_jobs():
 
     Shows all registered job handlers with their names.
     """
-    # Initialize config (minimal, no external connections needed)
-    try:
-        config = Config()
-        CLIDependencies.initialize(config)
-    except Exception as e:
-        logger.warning(f"Could not initialize config: {e}")
-
-    # Register all jobs
-    register_all_jobs()
-
-    # List jobs
     jobs = JobRegistry.list_jobs()
 
     if not jobs:
@@ -105,8 +67,14 @@ def list_jobs():
         return
 
     click.echo("Available jobs:")
-    for job in sorted(jobs):
-        click.echo(f"  - {job}")
+    for job_name in sorted(jobs):
+        # Display as kebab-case (CLI format)
+        cmd_name = job_name.replace('_', '-')
+        click.echo(f"  - {cmd_name}")
+
+
+# Register all jobs at module load time
+register_all_jobs(job_group, _init_deps, _cleanup_deps)
 
 
 if __name__ == "__main__":

--- a/src/entrypoints/cli/job_handler.py
+++ b/src/entrypoints/cli/job_handler.py
@@ -16,12 +16,13 @@ class JobHandler:
     Dispatches job execution to registered handlers.
     """
 
-    async def execute(self, job_name: str) -> None:
+    async def execute(self, job_name: str, **kwargs) -> None:
         """
         Execute job by name using registry lookup
 
         Args:
             job_name: Job identifier (registered function name)
+            **kwargs: Job arguments to pass to handler
         """
         # Get handler from registry
         handler = JobRegistry.get(job_name)
@@ -34,10 +35,10 @@ class JobHandler:
             )
 
         # Execute handler
-        logger.info(f"Executing job: {job_name}")
+        logger.info(f"Executing job: {job_name} with args: {kwargs}")
 
         try:
-            await handler()
+            await handler(**kwargs)
             logger.info(f"Job completed successfully: {job_name}")
         except Exception as e:
             logger.error(f"Job execution failed: {job_name}, error: {e}", exc_info=True)

--- a/src/entrypoints/cli/job_registry.py
+++ b/src/entrypoints/cli/job_registry.py
@@ -2,17 +2,19 @@
 Job Registry Module
 
 Provides decorator-based job handler registration for CLI jobs.
-Mirrors TaskRegistry pattern from Worker entrypoint.
+Supports argument passing via Click options auto-generated from function signature.
 """
+import inspect
+import asyncio
 from typing import Callable, Dict, Optional
-from functools import wraps
+
+import click
 
 
 class JobRegistry:
     """
     Job handler registry for dynamic routing
 
-    Mirrors TaskRegistry pattern from Worker entrypoint.
     Manages registration and lookup of job handlers marked with @job decorator.
     """
 
@@ -63,23 +65,72 @@ def job(func: Callable) -> Callable:
     Decorator for marking job handler functions
 
     Automatically uses function name as job name.
-    All job handlers must be async functions with no parameters.
+    Stores function signature for Click option generation.
 
     Args:
-        func: Async job handler function (no parameters)
+        func: Async job handler function
 
     Example:
         @job
-        async def cleanup_items() -> None:
-            # Clean up old items...
+        async def process_item(item_id: str) -> None:
+            # Process item...
             pass
     """
-    # Use function name as job name
     func._job_name = func.__name__
     func._is_job_handler = True
+    func._job_signature = inspect.signature(func)
+    return func
 
-    @wraps(func)
-    async def wrapper():
-        return await func()
 
-    return wrapper
+def create_job_command(
+    handler: Callable,
+    initialize_deps: Callable,
+    cleanup_deps: Callable
+) -> click.Command:
+    """
+    Create Click Command from job handler
+
+    Analyzes function signature and generates Click options.
+    All arguments are treated as STRING type.
+
+    Args:
+        handler: Decorated async job handler
+        initialize_deps: Dependency initialization function
+        cleanup_deps: Dependency cleanup function
+
+    Returns:
+        click.Command: Configured Click command
+    """
+    sig = handler._job_signature
+
+    # Build Click options from signature (all STRING type)
+    params = []
+    for name, param in sig.parameters.items():
+        has_default = param.default is not inspect.Parameter.empty
+        params.append(click.Option(
+            ['--' + name.replace('_', '-')],
+            type=click.STRING,
+            required=not has_default,
+            default=param.default if has_default else None,
+            help=f"{name} parameter",
+        ))
+
+    def callback(**kwargs):
+        """Synchronous wrapper for async handler"""
+        async def run():
+            initialize_deps()
+            try:
+                await handler(**kwargs)
+            finally:
+                cleanup_deps()
+        asyncio.run(run())
+
+    # Command name: snake_case -> kebab-case
+    cmd_name = handler._job_name.replace('_', '-')
+
+    return click.Command(
+        name=cmd_name,
+        callback=callback,
+        params=params,
+        help=handler.__doc__,
+    )

--- a/src/entrypoints/cli/jobs/__init__.py
+++ b/src/entrypoints/cli/jobs/__init__.py
@@ -4,9 +4,12 @@ Job Handlers (Entry Point)
 CLI job handlers that delegate to Service Layer.
 Similar to Worker task handlers pattern.
 """
+from typing import Callable
+
+import click
 from loguru import logger
 
-from entrypoints.cli.job_registry import JobRegistry
+from entrypoints.cli.job_registry import JobRegistry, create_job_command
 from . import sample
 
 
@@ -16,14 +19,21 @@ JOB_MODULES = [
 ]
 
 
-def register_all_jobs() -> None:
+def register_all_jobs(
+    job_group: click.Group,
+    initialize_deps: Callable,
+    cleanup_deps: Callable
+) -> None:
     """
-    Auto-discover and register all job handlers
+    Auto-discover and register all job handlers as Click commands
 
-    Mirrors Worker's register_all_tasks() pattern.
     Scans all job modules for functions decorated with @job.
+    Creates Click commands with auto-generated options from function signature.
 
-    Similar to FastAPI's app.include_router() pattern.
+    Args:
+        job_group: Click Group to add commands to
+        initialize_deps: Dependency initialization function
+        cleanup_deps: Dependency cleanup function
     """
     for module in JOB_MODULES:
         module_name = module.__name__.split('.')[-1]
@@ -31,8 +41,14 @@ def register_all_jobs() -> None:
         for name in dir(module):
             func = getattr(module, name)
             if callable(func) and hasattr(func, '_is_job_handler'):
+                # Create Click command from handler
+                cmd = create_job_command(func, initialize_deps, cleanup_deps)
+                job_group.add_command(cmd)
+
+                # Register in JobRegistry for programmatic access
                 JobRegistry.register(func._job_name, func)
-                logger.info(
-                    f"Registered job: {func._job_name} "
+
+                logger.debug(
+                    f"Registered job: {cmd.name} "
                     f"(module={module_name})"
                 )

--- a/src/entrypoints/cli/jobs/sample.py
+++ b/src/entrypoints/cli/jobs/sample.py
@@ -18,7 +18,7 @@ async def process_item(item_id: str) -> None:
     Demonstrates get_item (Read) usage pattern.
 
     Example:
-        void job run process_item --item-id 507f1f77bcf86cd799439011
+        ./void run job process-item --item-id 507f1f77bcf86cd799439011
     """
     logger.info(f"Starting process_item job for item_id: {item_id}")
 

--- a/void
+++ b/void
@@ -39,7 +39,7 @@ case "$2" in
             python -m entrypoints.cli.app job list
             exit 1
         fi
-        python -m entrypoints.cli.app job run "$3"
+        python -m entrypoints.cli.app job "${@:3}"
         ;;
     *)
         echo "Usage: void run <api|worker|job> [JOB_NAME]"

--- a/void
+++ b/void
@@ -31,14 +31,6 @@ case "$2" in
         python -m entrypoints.worker.app
         ;;
     job)
-        if [ -z "$3" ]; then
-            echo "Error: Job name required"
-            echo "Usage: void run job <JOB_NAME>"
-            echo ""
-            echo "Available jobs:"
-            python -m entrypoints.cli.app job list
-            exit 1
-        fi
         python -m entrypoints.cli.app job "${@:3}"
         ;;
     *)


### PR DESCRIPTION
## Summary
- CLI job 실행 시 함수 시그니처 기반으로 Click 옵션을 자동 생성하여 인자 전달 지원
- `@job` 데코레이터가 함수 시그니처 메타데이터 저장
- `create_job_command()`로 Click Command 동적 생성
- snake_case → kebab-case 자동 변환

## Usage
```bash
# 인자 전달
./void run job process-item --item-id 507f1f77bcf86cd799439011

# 도움말
./void run job process-item --help

# job 목록
./void run job list
```

## Test plan
- [x] `./void run job list` - job 목록 표시 확인
- [x] `./void run job process-item --help` - 옵션 도움말 표시 확인
- [x] `./void run job process-item --item-id xxx` - 인자 전달 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)