### PR TITLE
refactor: implement auto-discovery pattern for Task/Job registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,18 +206,20 @@ async def lifespan(app: FastAPI):
 
 ---
 
-### 7. Task/Job Registry Pattern
-**Worker**: `@task` 데코레이터로 SQS 메시지 핸들러 등록
-**CLI**: `@job` 데코레이터로 cronjob/background job 등록 (함수 시그니처 기반 Click 옵션 자동 생성)
+### 7. Task/Job Registry Pattern (Auto-Discovery)
+**1단계 등록**: 데코레이터만 붙이면 자동 등록 (패키지 내 파일 추가 시 `__init__.py` 수정 불필요)
+
+**Worker**: `@task` 데코레이터로 SQS 메시지 핸들러 즉시 등록
+**CLI**: `@job` 데코레이터로 cronjob/background job 즉시 등록 (함수 시그니처 기반 Click 옵션 자동 생성)
 
 ```python
-# Worker task (Write 예시)
+# Worker task - @task 붙이면 즉시 TaskRegistry에 등록
 @task
 async def process_item(data: Dict[str, Any]) -> None:
     service = ItemService(db_client)
     await service.create_item(name=data["name"], ...)
 
-# CLI job - 함수 파라미터가 자동으로 --option으로 변환됨
+# CLI job - @job 붙이면 즉시 JobRegistry에 등록
 @job
 async def process_item(item_id: str) -> None:
     """Process item by ID"""  # docstring이 --help에 표시됨
@@ -225,6 +227,11 @@ async def process_item(item_id: str) -> None:
     item = await service.get_item(item_id)
 # 실행: ./void run job process-item --item-id xxx
 ```
+
+**Auto-Discovery 동작 원리**:
+- `discover_and_import_tasks()` / `discover_and_import_jobs()` 함수가 패키지 내 모든 `.py` 파일을 재귀적으로 import
+- `@task` / `@job` 데코레이터가 실행되면서 즉시 Registry에 등록
+- 새 파일 추가 시 `__init__.py` 수정 없이 자동 인식
 
 ---
 
@@ -242,7 +249,7 @@ async def process_item(item_id: str) -> None:
 ./void run worker
 ```
 
-**구조**: `app.py` → `dependencies.initialize()` → `register_all_tasks()` → `consumer.start()`
+**구조**: `app.py` → `dependencies.initialize()` → `discover_and_import_tasks()` → `consumer.start()`
 
 ### CLI (Click)
 ```bash
@@ -252,11 +259,12 @@ async def process_item(item_id: str) -> None:
 ./void run job process-item --item-id 507f1f77bcf86cd799439011  # job 실행
 ```
 
-**구조**: `app.py` → `register_all_jobs()` → 동적 Click Command 생성
+**구조**: `app.py` → `discover_and_import_jobs()` → `create_all_job_commands()` → 동적 Click Command 생성
 **특징**:
 - `@job` 데코레이터가 함수 시그니처를 분석하여 Click 옵션 자동 생성
 - snake_case 함수명 → kebab-case 커맨드명 변환
 - 함수 docstring이 `--help`에 표시됨
+- 새 파일 추가 시 `__init__.py` 수정 불필요
 
 ---
 
@@ -306,11 +314,11 @@ SQS_QUEUE_URL=https://sqs.ap-northeast-2.amazonaws.com/xxx/queue.fifo
 
 ### New Worker Task
 1. `entrypoints/worker/tasks/xxx.py` - @task 데코레이터로 핸들러 정의
-2. `entrypoints/worker/tasks/__init__.py` - TASK_MODULES에 추가
+   - `__init__.py` 수정 불필요 (Auto-discovery)
 
 ### New CLI Job
 1. `entrypoints/cli/jobs/xxx.py` - @job 데코레이터로 핸들러 정의
-2. `entrypoints/cli/jobs/__init__.py` - JOB_MODULES에 추가
+   - `__init__.py` 수정 불필요 (Auto-discovery)
 
 ### New Exception
 1. `domain/exceptions.py` - `DomainError` 또는 적절한 기본 예외 상속

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,18 +206,20 @@ async def lifespan(app: FastAPI):
 
 ---
 
-### 7. Task/Job Registry Pattern
-**Worker**: `@task` 데코레이터로 SQS 메시지 핸들러 등록
-**CLI**: `@job` 데코레이터로 cronjob/background job 등록 (함수 시그니처 기반 Click 옵션 자동 생성)
+### 7. Task/Job Registry Pattern (Auto-Discovery)
+**1단계 등록**: 데코레이터만 붙이면 자동 등록 (패키지 내 파일 추가 시 `__init__.py` 수정 불필요)
+
+**Worker**: `@task` 데코레이터로 SQS 메시지 핸들러 즉시 등록
+**CLI**: `@job` 데코레이터로 cronjob/background job 즉시 등록 (함수 시그니처 기반 Click 옵션 자동 생성)
 
 ```python
-# Worker task (Write 예시)
+# Worker task - @task 붙이면 즉시 TaskRegistry에 등록
 @task
 async def process_item(data: Dict[str, Any]) -> None:
     service = ItemService(db_client)
     await service.create_item(name=data["name"], ...)
 
-# CLI job - 함수 파라미터가 자동으로 --option으로 변환됨
+# CLI job - @job 붙이면 즉시 JobRegistry에 등록
 @job
 async def process_item(item_id: str) -> None:
     """Process item by ID"""  # docstring이 --help에 표시됨
@@ -225,6 +227,11 @@ async def process_item(item_id: str) -> None:
     item = await service.get_item(item_id)
 # 실행: ./void run job process-item --item-id xxx
 ```
+
+**Auto-Discovery 동작 원리**:
+- `discover_tasks()` / `discover_jobs()` 함수가 패키지 내 모든 `.py` 파일을 재귀적으로 import
+- `@task` / `@job` 데코레이터가 실행되면서 즉시 Registry에 등록
+- 새 파일 추가 시 `__init__.py` 수정 없이 자동 인식
 
 ---
 
@@ -242,7 +249,7 @@ async def process_item(item_id: str) -> None:
 ./void run worker
 ```
 
-**구조**: `app.py` → `dependencies.initialize()` → `register_all_tasks()` → `consumer.start()`
+**구조**: `app.py` → `dependencies.initialize()` → `discover_tasks()` → `consumer.start()`
 
 ### CLI (Click)
 ```bash
@@ -252,11 +259,12 @@ async def process_item(item_id: str) -> None:
 ./void run job process-item --item-id 507f1f77bcf86cd799439011  # job 실행
 ```
 
-**구조**: `app.py` → `register_all_jobs()` → 동적 Click Command 생성
+**구조**: `app.py` → `discover_jobs()` → `create_all_job_commands()` → 동적 Click Command 생성
 **특징**:
 - `@job` 데코레이터가 함수 시그니처를 분석하여 Click 옵션 자동 생성
 - snake_case 함수명 → kebab-case 커맨드명 변환
 - 함수 docstring이 `--help`에 표시됨
+- 새 파일 추가 시 `__init__.py` 수정 불필요
 
 ---
 
@@ -306,11 +314,11 @@ SQS_QUEUE_URL=https://sqs.ap-northeast-2.amazonaws.com/xxx/queue.fifo
 
 ### New Worker Task
 1. `entrypoints/worker/tasks/xxx.py` - @task 데코레이터로 핸들러 정의
-2. `entrypoints/worker/tasks/__init__.py` - TASK_MODULES에 추가
+   - `__init__.py` 수정 불필요 (Auto-discovery)
 
 ### New CLI Job
 1. `entrypoints/cli/jobs/xxx.py` - @job 데코레이터로 핸들러 정의
-2. `entrypoints/cli/jobs/__init__.py` - JOB_MODULES에 추가
+   - `__init__.py` 수정 불필요 (Auto-discovery)
 
 ### New Exception
 1. `domain/exceptions.py` - `DomainError` 또는 적절한 기본 예외 상속

--- a/src/__about__.py
+++ b/src/__about__.py
@@ -1,4 +1,4 @@
 """Project metadata"""
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __app_name__ = "VOID"
 __author__ = "IML"

--- a/src/entrypoints/cli/app.py
+++ b/src/entrypoints/cli/app.py
@@ -9,8 +9,8 @@ from loguru import logger
 from config import Config
 from __about__ import __version__
 from .dependencies import CLIDependencies
-from .jobs import register_all_jobs
-from .job_registry import JobRegistry
+from .jobs import discover_and_import_jobs
+from .job_registry import JobRegistry, create_all_job_commands
 
 
 # Global state for lazy initialization
@@ -75,8 +75,9 @@ def list_jobs():
         click.echo(f"  - {cmd_name}")
 
 
-# Register all jobs at module load time
-register_all_jobs(job_group, _init_deps, _cleanup_deps)
+# Auto-discover and register all jobs at module load time
+discover_and_import_jobs()
+create_all_job_commands(job_group, _init_deps, _cleanup_deps)
 
 
 if __name__ == "__main__":

--- a/src/entrypoints/cli/app.py
+++ b/src/entrypoints/cli/app.py
@@ -9,8 +9,8 @@ from loguru import logger
 from config import Config
 from __about__ import __version__
 from .dependencies import CLIDependencies
-from .jobs import register_all_jobs
-from .job_registry import JobRegistry
+from .jobs import discover_jobs
+from .job_registry import JobRegistry, create_all_job_commands
 
 
 # Global state for lazy initialization
@@ -75,8 +75,9 @@ def list_jobs():
         click.echo(f"  - {cmd_name}")
 
 
-# Register all jobs at module load time
-register_all_jobs(job_group, _init_deps, _cleanup_deps)
+# Auto-discover and register all jobs at module load time
+discover_jobs()
+create_all_job_commands(job_group, _init_deps, _cleanup_deps)
 
 
 if __name__ == "__main__":

--- a/src/entrypoints/cli/job_registry.py
+++ b/src/entrypoints/cli/job_registry.py
@@ -3,10 +3,11 @@ Job Registry Module
 
 Provides decorator-based job handler registration for CLI jobs.
 Supports argument passing via Click options auto-generated from function signature.
+Uses immediate registration at decorator time (auto-discovery pattern).
 """
-import inspect
 import asyncio
-from typing import Callable, Dict, Optional
+import inspect
+from typing import Callable, Dict, List, Optional
 
 import click
 
@@ -28,8 +29,14 @@ class JobRegistry:
         Args:
             job_name: Job identifier (function name)
             handler: Async job handler function
+
+        Note:
+            Allows duplicate registration of same handler (idempotent).
+            Raises error only if different handler attempts to use same name.
         """
         if job_name in cls._handlers:
+            if cls._handlers[job_name] is handler:
+                return  # Same handler, idempotent
             raise ValueError(f"Job already registered: {job_name}")
         cls._handlers[job_name] = handler
 
@@ -44,7 +51,17 @@ class JobRegistry:
         return cls._handlers.get(job_name)
 
     @classmethod
-    def list_jobs(cls) -> list[str]:
+    def get_all_handlers(cls) -> Dict[str, Callable]:
+        """
+        Get all registered handlers
+
+        Returns:
+            Dict of job_name -> handler mappings
+        """
+        return cls._handlers.copy()
+
+    @classmethod
+    def list_jobs(cls) -> List[str]:
         """
         List all registered job names
         """
@@ -62,13 +79,9 @@ class JobRegistry:
 
 def job(func: Callable) -> Callable:
     """
-    Decorator for marking job handler functions
+    Decorator for marking and registering job handler functions
 
-    Automatically uses function name as job name.
-    Stores function signature for Click option generation.
-
-    Args:
-        func: Async job handler function
+    Immediately registers the handler with JobRegistry at decoration time.
 
     Example:
         @job
@@ -79,6 +92,7 @@ def job(func: Callable) -> Callable:
     func._job_name = func.__name__
     func._is_job_handler = True
     func._job_signature = inspect.signature(func)
+    JobRegistry.register(func._job_name, func)
     return func
 
 
@@ -105,14 +119,14 @@ def create_job_command(
 
     # Build Click options from signature (all STRING type)
     params = []
-    for name, param in sig.parameters.items():
+    for param_name, param in sig.parameters.items():
         has_default = param.default is not inspect.Parameter.empty
         params.append(click.Option(
-            ['--' + name.replace('_', '-')],
+            ['--' + param_name.replace('_', '-')],
             type=click.STRING,
             required=not has_default,
             default=param.default if has_default else None,
-            help=f"{name} parameter",
+            help=f"{param_name} parameter",
         ))
 
     def callback(**kwargs):
@@ -134,3 +148,26 @@ def create_job_command(
         params=params,
         help=handler.__doc__,
     )
+
+
+def create_all_job_commands(
+    job_group: click.Group,
+    initialize_deps: Callable,
+    cleanup_deps: Callable
+) -> None:
+    """
+    Create Click Commands for all registered jobs
+
+    Iterates through JobRegistry and creates Click commands for each handler.
+
+    Args:
+        job_group: Click Group to add commands to
+        initialize_deps: Dependency initialization function
+        cleanup_deps: Dependency cleanup function
+    """
+    from loguru import logger
+
+    for handler in JobRegistry.get_all_handlers().values():
+        cmd = create_job_command(handler, initialize_deps, cleanup_deps)
+        job_group.add_command(cmd)
+        logger.debug(f"Registered job command: {cmd.name}")

--- a/src/entrypoints/cli/jobs/__init__.py
+++ b/src/entrypoints/cli/jobs/__init__.py
@@ -3,52 +3,52 @@ Job Handlers (Entry Point)
 
 CLI job handlers that delegate to Service Layer.
 Similar to Worker task handlers pattern.
-"""
-from typing import Callable
 
-import click
+Auto-discovery: Just add @job decorator to any function in this package.
+No need to modify this file when adding new jobs.
+"""
+import importlib
+from pathlib import Path
+
 from loguru import logger
 
-from entrypoints.cli.job_registry import JobRegistry, create_job_command
-from . import sample
 
-
-# List of all job modules
-JOB_MODULES = [
-    sample,
-]
-
-
-def register_all_jobs(
-    job_group: click.Group,
-    initialize_deps: Callable,
-    cleanup_deps: Callable
-) -> None:
+def discover_and_import_jobs() -> None:
     """
-    Auto-discover and register all job handlers as Click commands
+    Auto-discover and import all job modules recursively
 
-    Scans all job modules for functions decorated with @job.
-    Creates Click commands with auto-generated options from function signature.
+    Scans all .py files in this package and subpackages.
+    @job decorated functions are registered automatically on import.
+    """
+    jobs_dir = Path(__file__).parent
+    package_name = __name__
+    _import_modules_recursive(jobs_dir, package_name)
+
+
+def _import_modules_recursive(directory: Path, package_prefix: str) -> None:
+    """
+    Recursively import all Python modules in directory
 
     Args:
-        job_group: Click Group to add commands to
-        initialize_deps: Dependency initialization function
-        cleanup_deps: Dependency cleanup function
+        directory: Directory to scan
+        package_prefix: Python package prefix for imports
     """
-    for module in JOB_MODULES:
-        module_name = module.__name__.split('.')[-1]
+    for item in sorted(directory.iterdir()):
+        # Skip __pycache__, hidden files, and dunder modules
+        if item.name.startswith(('__', '.')):
+            continue
 
-        for name in dir(module):
-            func = getattr(module, name)
-            if callable(func) and hasattr(func, '_is_job_handler'):
-                # Create Click command from handler
-                cmd = create_job_command(func, initialize_deps, cleanup_deps)
-                job_group.add_command(cmd)
+        if item.is_file() and item.suffix == '.py':
+            module_name = f"{package_prefix}.{item.stem}"
+            try:
+                importlib.import_module(module_name)
+                logger.debug(f"Imported job module: {module_name}")
+            except Exception as e:
+                logger.error(f"Failed to import {module_name}: {e}")
+                raise
 
-                # Register in JobRegistry for programmatic access
-                JobRegistry.register(func._job_name, func)
-
-                logger.debug(
-                    f"Registered job: {cmd.name} "
-                    f"(module={module_name})"
-                )
+        elif item.is_dir():
+            # Check if it's a Python package (has __init__.py)
+            init_file = item / "__init__.py"
+            if init_file.exists():
+                _import_modules_recursive(item, f"{package_prefix}.{item.name}")

--- a/src/entrypoints/cli/jobs/__init__.py
+++ b/src/entrypoints/cli/jobs/__init__.py
@@ -3,52 +3,52 @@ Job Handlers (Entry Point)
 
 CLI job handlers that delegate to Service Layer.
 Similar to Worker task handlers pattern.
-"""
-from typing import Callable
 
-import click
+Auto-discovery: Just add @job decorator to any function in this package.
+No need to modify this file when adding new jobs.
+"""
+import importlib
+from pathlib import Path
+
 from loguru import logger
 
-from entrypoints.cli.job_registry import JobRegistry, create_job_command
-from . import sample
 
-
-# List of all job modules
-JOB_MODULES = [
-    sample,
-]
-
-
-def register_all_jobs(
-    job_group: click.Group,
-    initialize_deps: Callable,
-    cleanup_deps: Callable
-) -> None:
+def discover_jobs() -> None:
     """
-    Auto-discover and register all job handlers as Click commands
+    Auto-discover and import all job modules recursively
 
-    Scans all job modules for functions decorated with @job.
-    Creates Click commands with auto-generated options from function signature.
+    Scans all .py files in this package and subpackages.
+    @job decorated functions are registered automatically on import.
+    """
+    jobs_dir = Path(__file__).parent
+    package_name = __name__
+    _import_modules_recursive(jobs_dir, package_name)
+
+
+def _import_modules_recursive(directory: Path, package_prefix: str) -> None:
+    """
+    Recursively import all Python modules in directory
 
     Args:
-        job_group: Click Group to add commands to
-        initialize_deps: Dependency initialization function
-        cleanup_deps: Dependency cleanup function
+        directory: Directory to scan
+        package_prefix: Python package prefix for imports
     """
-    for module in JOB_MODULES:
-        module_name = module.__name__.split('.')[-1]
+    for item in sorted(directory.iterdir()):
+        # Skip __pycache__, hidden files, and dunder modules
+        if item.name.startswith(('__', '.')):
+            continue
 
-        for name in dir(module):
-            func = getattr(module, name)
-            if callable(func) and hasattr(func, '_is_job_handler'):
-                # Create Click command from handler
-                cmd = create_job_command(func, initialize_deps, cleanup_deps)
-                job_group.add_command(cmd)
+        if item.is_file() and item.suffix == '.py':
+            module_name = f"{package_prefix}.{item.stem}"
+            try:
+                importlib.import_module(module_name)
+                logger.debug(f"Imported job module: {module_name}")
+            except Exception as e:
+                logger.error(f"Failed to import {module_name}: {e}")
+                raise
 
-                # Register in JobRegistry for programmatic access
-                JobRegistry.register(func._job_name, func)
-
-                logger.debug(
-                    f"Registered job: {cmd.name} "
-                    f"(module={module_name})"
-                )
+        elif item.is_dir():
+            # Check if it's a Python package (has __init__.py)
+            init_file = item / "__init__.py"
+            if init_file.exists():
+                _import_modules_recursive(item, f"{package_prefix}.{item.name}")

--- a/src/entrypoints/worker/app.py
+++ b/src/entrypoints/worker/app.py
@@ -7,7 +7,7 @@ import asyncio
 from loguru import logger
 
 from config import Config
-from .tasks import register_all_tasks
+from .tasks import discover_tasks
 from .task_registry import TaskRegistry
 from .dependencies import WorkerDependencies
 from .consumer import SQSConsumer
@@ -24,8 +24,8 @@ async def main():
     WorkerDependencies.initialize(config)
     logger.info("Worker dependencies initialized")
 
-    # Initialize and register all task handlers
-    register_all_tasks()
+    # Auto-discover and import all task handlers
+    discover_tasks()
     logger.info(f"Registered task handlers: {TaskRegistry.list_tasks()}")
 
     # Create and start consumer

--- a/src/entrypoints/worker/app.py
+++ b/src/entrypoints/worker/app.py
@@ -7,7 +7,7 @@ import asyncio
 from loguru import logger
 
 from config import Config
-from .tasks import register_all_tasks
+from .tasks import discover_and_import_tasks
 from .task_registry import TaskRegistry
 from .dependencies import WorkerDependencies
 from .consumer import SQSConsumer
@@ -24,8 +24,8 @@ async def main():
     WorkerDependencies.initialize(config)
     logger.info("Worker dependencies initialized")
 
-    # Initialize and register all task handlers
-    register_all_tasks()
+    # Auto-discover and import all task handlers
+    discover_and_import_tasks()
     logger.info(f"Registered task handlers: {TaskRegistry.list_tasks()}")
 
     # Create and start consumer

--- a/src/entrypoints/worker/task_registry.py
+++ b/src/entrypoints/worker/task_registry.py
@@ -1,17 +1,17 @@
 """
 Task Registry Module
 
-Provides decorator-based task handler registration for extensible task routing
+Provides decorator-based task handler registration for extensible task routing.
+Supports immediate registration at decorator time (auto-discovery pattern).
 """
-from typing import Callable, Dict, Optional
-from functools import wraps
+from typing import Callable, Dict, List, Optional
 
 
 class TaskRegistry:
     """
     Task handler registry for dynamic routing
 
-    Provides centralized registry for task handlers with automatic discovery
+    Provides centralized registry for task handlers with automatic discovery.
     """
 
     _handlers: Dict[str, Callable] = {}
@@ -19,13 +19,19 @@ class TaskRegistry:
     @classmethod
     def register(cls, task_name: str, handler: Callable) -> None:
         """
-        Register task handler (bound method)
+        Register task handler
 
         Args:
             task_name: Task name identifier
-            handler: Task handler function (bound method)
+            handler: Task handler function
+
+        Note:
+            Allows duplicate registration of same handler (idempotent).
+            Raises error only if different handler attempts to use same name.
         """
         if task_name in cls._handlers:
+            if cls._handlers[task_name] is handler:
+                return  # Same handler, idempotent
             raise ValueError(f"Task handler already registered: {task_name}")
 
         cls._handlers[task_name] = handler
@@ -41,7 +47,17 @@ class TaskRegistry:
         return cls._handlers.get(task_name)
 
     @classmethod
-    def list_tasks(cls) -> list[str]:
+    def get_all_handlers(cls) -> Dict[str, Callable]:
+        """
+        Get all registered handlers
+
+        Returns:
+            Dict of task_name -> handler mappings
+        """
+        return cls._handlers.copy()
+
+    @classmethod
+    def list_tasks(cls) -> List[str]:
         """
         List all registered task names
         """
@@ -59,18 +75,9 @@ class TaskRegistry:
 
 def task(func: Callable) -> Callable:
     """
-    Decorator for marking task handler functions
+    Decorator for marking and registering task handler functions
 
-    Automatically uses function name as task name.
-    Similar to FastAPI's @router.get() decorator pattern.
-
-    Args:
-        func: Task handler function
-
-    Note:
-        - Function name becomes the task name
-        - Actual registration happens in register_all_tasks()
-        - Handler must accept (data: Dict[str, Any]) -> None signature
+    Immediately registers the handler with TaskRegistry at decoration time.
 
     Example:
         @task
@@ -78,12 +85,8 @@ def task(func: Callable) -> Callable:
             item_id = data['item_id']
             # Process item...
     """
-    # Use function name as task name
-    func._task_name = func.__name__
+    task_name = func.__name__
+    TaskRegistry.register(task_name, func)
     func._is_task_handler = True
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-
-    return wrapper
+    func._task_name = task_name
+    return func

--- a/src/entrypoints/worker/tasks/__init__.py
+++ b/src/entrypoints/worker/tasks/__init__.py
@@ -3,34 +3,52 @@ Task Handlers (Entry Point)
 
 Worker task handlers that delegate to Service Layer.
 Similar to FastAPI route handlers that call services.
+
+Auto-discovery: Just add @task decorator to any function in this package.
+No need to modify this file when adding new tasks.
 """
+import importlib
+from pathlib import Path
+
 from loguru import logger
-from entrypoints.worker.task_registry import TaskRegistry
-
-# Import all task modules
-from . import sample
-
-# All task modules
-TASK_MODULES = [sample]
 
 
-def register_all_tasks() -> None:
+def discover_tasks() -> None:
     """
-    Auto-discover and register all task handlers
+    Auto-discover and import all task modules recursively
 
-    Scans all task modules and registers functions marked with @task.
-    Similar to FastAPI's app.include_router() pattern.
+    Scans all .py files in this package and subpackages.
+    @task decorated functions are registered automatically on import.
     """
-    for module in TASK_MODULES:
-        module_name = module.__name__.split('.')[-1]
+    tasks_dir = Path(__file__).parent
+    package_name = __name__
+    _import_modules_recursive(tasks_dir, package_name)
 
-        # Scan module for task handlers
-        for name in dir(module):
-            func = getattr(module, name)
-            if callable(func) and hasattr(func, '_is_task_handler'):
-                task_name = func._task_name
-                TaskRegistry.register(task_name, func)
-                logger.info(
-                    f"Registered task: {task_name} "
-                    f"(module={module_name}, func={name})"
-                )
+
+def _import_modules_recursive(directory: Path, package_prefix: str) -> None:
+    """
+    Recursively import all Python modules in directory
+
+    Args:
+        directory: Directory to scan
+        package_prefix: Python package prefix for imports
+    """
+    for item in sorted(directory.iterdir()):
+        # Skip __pycache__, hidden files, and dunder modules
+        if item.name.startswith(('__', '.')):
+            continue
+
+        if item.is_file() and item.suffix == '.py':
+            module_name = f"{package_prefix}.{item.stem}"
+            try:
+                importlib.import_module(module_name)
+                logger.debug(f"Imported task module: {module_name}")
+            except Exception as e:
+                logger.error(f"Failed to import {module_name}: {e}")
+                raise
+
+        elif item.is_dir():
+            # Check if it's a Python package (has __init__.py)
+            init_file = item / "__init__.py"
+            if init_file.exists():
+                _import_modules_recursive(item, f"{package_prefix}.{item.name}")

--- a/src/entrypoints/worker/tasks/__init__.py
+++ b/src/entrypoints/worker/tasks/__init__.py
@@ -3,34 +3,52 @@ Task Handlers (Entry Point)
 
 Worker task handlers that delegate to Service Layer.
 Similar to FastAPI route handlers that call services.
+
+Auto-discovery: Just add @task decorator to any function in this package.
+No need to modify this file when adding new tasks.
 """
+import importlib
+from pathlib import Path
+
 from loguru import logger
-from entrypoints.worker.task_registry import TaskRegistry
-
-# Import all task modules
-from . import sample
-
-# All task modules
-TASK_MODULES = [sample]
 
 
-def register_all_tasks() -> None:
+def discover_and_import_tasks() -> None:
     """
-    Auto-discover and register all task handlers
+    Auto-discover and import all task modules recursively
 
-    Scans all task modules and registers functions marked with @task.
-    Similar to FastAPI's app.include_router() pattern.
+    Scans all .py files in this package and subpackages.
+    @task decorated functions are registered automatically on import.
     """
-    for module in TASK_MODULES:
-        module_name = module.__name__.split('.')[-1]
+    tasks_dir = Path(__file__).parent
+    package_name = __name__
+    _import_modules_recursive(tasks_dir, package_name)
 
-        # Scan module for task handlers
-        for name in dir(module):
-            func = getattr(module, name)
-            if callable(func) and hasattr(func, '_is_task_handler'):
-                task_name = func._task_name
-                TaskRegistry.register(task_name, func)
-                logger.info(
-                    f"Registered task: {task_name} "
-                    f"(module={module_name}, func={name})"
-                )
+
+def _import_modules_recursive(directory: Path, package_prefix: str) -> None:
+    """
+    Recursively import all Python modules in directory
+
+    Args:
+        directory: Directory to scan
+        package_prefix: Python package prefix for imports
+    """
+    for item in sorted(directory.iterdir()):
+        # Skip __pycache__, hidden files, and dunder modules
+        if item.name.startswith(('__', '.')):
+            continue
+
+        if item.is_file() and item.suffix == '.py':
+            module_name = f"{package_prefix}.{item.stem}"
+            try:
+                importlib.import_module(module_name)
+                logger.debug(f"Imported task module: {module_name}")
+            except Exception as e:
+                logger.error(f"Failed to import {module_name}: {e}")
+                raise
+
+        elif item.is_dir():
+            # Check if it's a Python package (has __init__.py)
+            init_file = item / "__init__.py"
+            if init_file.exists():
+                _import_modules_recursive(item, f"{package_prefix}.{item.name}")


### PR DESCRIPTION
## Summary
- Task/Job 등록 시 `@task`/`@job` 데코레이터만으로 자동 등록 (1단계 등록)
- `discover_tasks()` / `discover_jobs()` 함수가 패키지 내 모든 `.py` 파일을 재귀적으로 import
- 새 파일 추가 시 `__init__.py` 수정 불필요

## Changes
- `src/entrypoints/worker/tasks/__init__.py` - Auto-discovery 구현
- `src/entrypoints/cli/jobs/__init__.py` - Auto-discovery 구현
- `src/entrypoints/worker/task_registry.py` - Registry 개선
- `src/entrypoints/cli/job_registry.py` - Registry 개선
- `CLAUDE.md` - 문서 업데이트
- Version bump: `1.2.0` → `1.2.1`

## Test plan
- [ ] `./void run job list` - job 목록 확인
- [ ] `./void run worker` - task 등록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)